### PR TITLE
pin to digest instead of tag

### DIFF
--- a/packages/honeypot/src/Dockerfile
+++ b/packages/honeypot/src/Dockerfile
@@ -1,4 +1,5 @@
-FROM cgr.dev/chainguard/python:3.11.4
+# Python 3.11.4 See https://www.chainguard.dev/unchained/a-guide-on-how-to-use-chainguard-images-for-public-catalog-tier-users for more details on how to update this
+FROM cgr.dev/chainguard/python@sha256:bbaba40f4dfff902af5ec49793a8d42478cae07ad9fcd6eace93a55c348a2aa6 
 
 WORKDIR /honeypot-working-dir
 


### PR DESCRIPTION
Resolves #21 

Future updates to the base image will probably require some sleuthing using grep.app to find what others are publicly using, if the latest/latest-dev tags don't contain the right version of Python to update to (based off of https://www.chainguard.dev/unchained/a-guide-on-how-to-use-chainguard-images-for-public-catalog-tier-users)